### PR TITLE
Failing test to illustrate a problem with how TLDR gathers tests

### DIFF
--- a/tests/rake_task_test.rb
+++ b/tests/rake_task_test.rb
@@ -60,4 +60,33 @@ class RakeTaskTest < Minitest::Test
       😁
     MSG
   end
+
+  def test_running_multiples_rake_tasks_in_one_process
+    result = TLDRunner.run_command("cd example/c && TLDR_OPTS=\"--seed 1\" bundle exec rake tldr b_tests")
+
+    assert_includes result.stdout, <<~MSG
+      👓
+      Command: bundle exec tldr --seed 1 --helper "spec/spec_helper.rb" "spec/math_spec.rb"
+      🌱 --seed 1
+
+      🏃 Running:
+
+      😁
+
+      Finished in 0ms.
+
+      1 test class, 1 test method, 0 failures, 0 errors, 0 skips
+      neat!
+      Command: bundle exec tldr --seed 1 --base-path "../b"
+      🌱 --seed 1
+
+      🏃 Running:
+
+      😁
+
+      Finished in 0ms.
+
+      1 test class, 1 test method, 0 failures, 0 errors, 0 skips
+    MSG
+  end
 end


### PR DESCRIPTION
TLDR gathers tests by recursively looking for descendants of the TLDR class. If you have multiple Rake tasks that look in different places for tests, that's all well and good, but the first Rake task that runs (because it's all in the same process) will load all of its tests and the second Rake task will, of course, find them, because they're still defined.

Decoupling path from test definition is generally good but in this particular case it is not fantastic. Makes me wonder if we should go back to shelling out from the Rake task to avoid pollution or if there's some other way to segregate things without messing up any other valid use cases

This PR just pushes up a failing test.