### PR TITLE
Improve assert/refute_pattern failure messages

### DIFF
--- a/lib/tldr/assertions.rb
+++ b/lib/tldr/assertions.rb
@@ -241,7 +241,7 @@ class TLDR
       begin
         yield
       rescue NoMatchingPatternError => e
-        assert false, Assertions.msg(message) { "Expected pattern match: #{e.message}" }
+        assert false, Assertions.msg(message) { "Expected pattern to match, but NoMatchingPatternError was raised: #{e.message}" }
       end
     end
 
@@ -250,7 +250,7 @@ class TLDR
 
       begin
         yield
-        refute true, Assertions.msg(message) { "Expected pattern not to match, but NoMatchingPatternError was raised" }
+        refute true, Assertions.msg(message) { "Expected pattern not to match, but NoMatchingPatternError was not raised" }
       rescue NoMatchingPatternError
       end
     end

--- a/tests/assertions_test.rb
+++ b/tests/assertions_test.rb
@@ -248,17 +248,17 @@ class AssertionsTest < AssertionTestCase
 
   def test_assert_pattern
     @subject.assert_pattern { [1, 2, 3] => [Integer, Integer, Integer] }
-    should_fail "Expected pattern match: [1, \"two\", 3]: Integer === \"two\" does not return true" do
+    should_fail "Expected pattern to match, but NoMatchingPatternError was raised: [1, \"two\", 3]: Integer === \"two\" does not return true" do
       @subject.assert_pattern { [1, "two", 3] => [Integer, Integer, Integer] }
     end
-    should_fail "Custom\nExpected pattern match: [1, \"two\", 3]: Integer === \"two\" does not return true" do
+    should_fail "Custom\nExpected pattern to match, but NoMatchingPatternError was raised: [1, \"two\", 3]: Integer === \"two\" does not return true" do
       @subject.assert_pattern("Custom") { [1, "two", 3] => [Integer, Integer, Integer] }
     end
   end
 
   def test_refute_pattern
     @subject.refute_pattern { [1, "two", 3] => [Integer, Integer, Integer] }
-    should_fail "Expected pattern not to match, but NoMatchingPatternError was raised" do
+    should_fail "Expected pattern not to match, but NoMatchingPatternError was not raised" do
       @subject.refute_pattern { [1, 2, 3] => [Integer, Integer, Integer] }
     end
   end


### PR DESCRIPTION
I noticed a slight issue in the failure message of refute_pattern, a missing "not", so I've fixed that, and also just made the assert_pattern failure message a bit more readable =)