### PR TITLE
Print backtrace of cancelled tests with new option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     name: Ruby ${{ matrix.ruby }}
     strategy:
       matrix:
-        ruby: ['3.1', '3.2', 'ruby-head']
+        ruby: ['3.1', '3.2', '3.3', 'ruby-head']
 
     steps:
     - uses: actions/checkout@v3

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ Usage: tldr [options] some_tests/**/*.rb some/path.rb:13 ...
         --no-dotfile                 Disable loading .tldr.yml dotfile
         --no-emoji                   Disable emoji in the output
     -v, --verbose                    Print stack traces for errors
+        --verbose-cancelled-trace    Print stack traces for cancelled tests
         --[no-]warnings              Print Ruby warnings (Default: true)
         --watch                      Run your tests continuously on file save (requires 'fswatch' to be installed)
         --yes-i-know                 Suppress TLDR report when suite runs over 1.8s

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ Usage: tldr [options] some_tests/**/*.rb some/path.rb:13 ...
         --no-dotfile                 Disable loading .tldr.yml dotfile
         --no-emoji                   Disable emoji in the output
     -v, --verbose                    Print stack traces for errors
-        --verbose-cancelled-trace    Print stack traces for cancelled tests
+        --print-interrupted-test-backtraces
+                                     Print stack traces for interrupted tests
         --[no-]warnings              Print Ruby warnings (Default: true)
         --watch                      Run your tests continuously on file save (requires 'fswatch' to be installed)
         --yes-i-know                 Suppress TLDR report when suite runs over 1.8s

--- a/lib/tldr/argv_parser.rb
+++ b/lib/tldr/argv_parser.rb
@@ -78,6 +78,10 @@ class TLDR
           options[:verbose] = verbose
         end
 
+        opts.on CONFLAGS[:verbose_cancelled_trace], "Print stack traces for cancelled tests" do |verbose_cancelled_trace|
+          options[:verbose_cancelled_trace] = verbose_cancelled_trace
+        end
+
         opts.on CONFLAGS[:warnings], "Print Ruby warnings (Default: true)" do |warnings|
           options[:warnings] = warnings
         end

--- a/lib/tldr/argv_parser.rb
+++ b/lib/tldr/argv_parser.rb
@@ -78,8 +78,8 @@ class TLDR
           options[:verbose] = verbose
         end
 
-        opts.on CONFLAGS[:verbose_cancelled_trace], "Print stack traces for cancelled tests" do |verbose_cancelled_trace|
-          options[:verbose_cancelled_trace] = verbose_cancelled_trace
+        opts.on CONFLAGS[:print_interrupted_test_backtraces], "Print stack traces for interrupted tests" do |print_interrupted_test_backtraces|
+          options[:print_interrupted_test_backtraces] = print_interrupted_test_backtraces
         end
 
         opts.on CONFLAGS[:warnings], "Print Ruby warnings (Default: true)" do |warnings|

--- a/lib/tldr/reporters/default.rb
+++ b/lib/tldr/reporters/default.rb
@@ -47,7 +47,7 @@ class TLDR
               "#{@icons.run} Completed #{test_results.size} of #{planned_tests.size} tests (#{((test_results.size.to_f / planned_tests.size) * 100).round}%) before running out of time.",
               (<<~WIP.chomp if wip_tests.any?),
                 #{@icons.wip} #{plural(wip_tests.size, "test was", "tests were")} cancelled in progress:
-                #{wip_tests.map { |wip_test| "  #{time_diff(wip_test.start_time, stop_time)}ms - #{describe(wip_test.test)}" }.join("\n")}
+                #{wip_tests.map { |wip_test| "  #{time_diff(wip_test.start_time, stop_time)}ms - #{describe(wip_test.test)}#{print_wip_backtrace(wip_test, indent: "    ") if @config.verbose_cancelled_trace}" }.join("\n")}
               WIP
               (<<~SLOW.chomp if test_results.any?),
                 #{@icons.slow} Your #{[10, test_results.size].min} slowest completed tests:
@@ -135,6 +135,12 @@ class TLDR
 
       def describe test, location = test.location
         "#{test.test_class}##{test.method_name} [#{location.locator}]"
+      end
+
+      def print_wip_backtrace wip_test, indent: ""
+        return unless wip_test.backtrace_at_exit
+
+        "\n#{indent}Backtrace at the point of cancellation:\n#{indent}#{wip_test.backtrace_at_exit.join("\n#{indent}")}"
       end
 
       def plural count, singular, plural = "#{singular}s"

--- a/lib/tldr/reporters/default.rb
+++ b/lib/tldr/reporters/default.rb
@@ -47,7 +47,7 @@ class TLDR
               "#{@icons.run} Completed #{test_results.size} of #{planned_tests.size} tests (#{((test_results.size.to_f / planned_tests.size) * 100).round}%) before running out of time.",
               (<<~WIP.chomp if wip_tests.any?),
                 #{@icons.wip} #{plural(wip_tests.size, "test was", "tests were")} cancelled in progress:
-                #{wip_tests.map { |wip_test| "  #{time_diff(wip_test.start_time, stop_time)}ms - #{describe(wip_test.test)}#{print_wip_backtrace(wip_test, indent: "    ") if @config.verbose_cancelled_trace}" }.join("\n")}
+                #{wip_tests.map { |wip_test| "  #{time_diff(wip_test.start_time, stop_time)}ms - #{describe(wip_test.test)}#{print_wip_backtrace(wip_test, indent: "    ") if @config.print_interrupted_test_backtraces}" }.join("\n")}
               WIP
               (<<~SLOW.chomp if test_results.any?),
                 #{@icons.slow} Your #{[10, test_results.size].min} slowest completed tests:

--- a/lib/tldr/runner.rb
+++ b/lib/tldr/runner.rb
@@ -52,8 +52,7 @@ class TLDR
     def run_test test, config, plan, reporter
       e = nil
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
-      wip_test = WIPTest.new(test, start_time)
-      wip_test.thread = Thread.current if config.verbose_cancelled_trace
+      wip_test = WIPTest.new(test, start_time, Thread.current)
       @wip << wip_test
       runtime = time_it(start_time) do
         instance = test.test_class.new

--- a/lib/tldr/runner.rb
+++ b/lib/tldr/runner.rb
@@ -20,6 +20,7 @@ class TLDR
           next if ENV["CI"] && !$stderr.tty?
           next if @run_aborted.true?
           @run_aborted.make_true
+          @wip.each(&:capture_backtrace_at_exit)
           reporter.after_tldr(plan.tests, @wip.dup, @results.dup)
           exit!(3)
         end
@@ -52,6 +53,7 @@ class TLDR
       e = nil
       start_time = Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond)
       wip_test = WIPTest.new(test, start_time)
+      wip_test.thread = Thread.current if config.verbose_cancelled_trace
       @wip << wip_test
       runtime = time_it(start_time) do
         instance = test.test_class.new

--- a/lib/tldr/value/config.rb
+++ b/lib/tldr/value/config.rb
@@ -3,6 +3,7 @@ class TLDR
     seed: "--seed",
     no_helper: "--no-helper",
     verbose: "--verbose",
+    verbose_cancelled_trace: "--verbose-cancelled-trace",
     reporter: "--reporter",
     helper_paths: "--helper",
     load_paths: "--load-path",
@@ -26,7 +27,7 @@ class TLDR
   PATH_FLAGS = [:paths, :helper_paths, :load_paths, :prepend_paths, :exclude_paths].freeze
   MOST_RECENTLY_MODIFIED_TAG = "MOST_RECENTLY_MODIFIED".freeze
   CONFIG_ATTRIBUTES = [
-    :paths, :seed, :no_helper, :verbose, :reporter,
+    :paths, :seed, :no_helper, :verbose, :verbose_cancelled_trace, :reporter,
     :helper_paths, :load_paths, :parallel, :names, :fail_fast, :no_emoji,
     :prepend_paths, :no_prepend, :exclude_paths, :exclude_names, :base_path,
     :no_dotfile, :warnings, :watch, :yes_i_know, :i_am_being_watched,
@@ -60,6 +61,7 @@ class TLDR
         seed: rand(10_000),
         no_helper: false,
         verbose: false,
+        verbose_cancelled_trace: false,
         reporter: Reporters::Default,
         parallel: true,
         names: [],
@@ -109,7 +111,7 @@ class TLDR
       end
 
       # Booleans
-      [:no_helper, :verbose, :fail_fast, :no_emoji, :no_prepend, :warnings, :yes_i_know, :i_am_being_watched].each do |key|
+      [:no_helper, :verbose, :verbose_cancelled_trace, :fail_fast, :no_emoji, :no_prepend, :warnings, :yes_i_know, :i_am_being_watched].each do |key|
         merged_args[key] = defaults[key] if merged_args[key].nil?
       end
 

--- a/lib/tldr/value/config.rb
+++ b/lib/tldr/value/config.rb
@@ -203,7 +203,7 @@ class TLDR
           next warnings ? "--warnings" : "--no-warnings"
         end
 
-        if defaults[key] == self[key]
+        if defaults[key] == self[key] && (key != :seed || !seed_set_intentionally)
           next
         elsif self[key].is_a?(Array)
           self[key].map { |value| [flag, stringify(key, value)] }

--- a/lib/tldr/value/config.rb
+++ b/lib/tldr/value/config.rb
@@ -3,7 +3,7 @@ class TLDR
     seed: "--seed",
     no_helper: "--no-helper",
     verbose: "--verbose",
-    verbose_cancelled_trace: "--verbose-cancelled-trace",
+    print_interrupted_test_backtraces: "--print-interrupted-test-backtraces",
     reporter: "--reporter",
     helper_paths: "--helper",
     load_paths: "--load-path",
@@ -27,7 +27,7 @@ class TLDR
   PATH_FLAGS = [:paths, :helper_paths, :load_paths, :prepend_paths, :exclude_paths].freeze
   MOST_RECENTLY_MODIFIED_TAG = "MOST_RECENTLY_MODIFIED".freeze
   CONFIG_ATTRIBUTES = [
-    :paths, :seed, :no_helper, :verbose, :verbose_cancelled_trace, :reporter,
+    :paths, :seed, :no_helper, :verbose, :print_interrupted_test_backtraces, :reporter,
     :helper_paths, :load_paths, :parallel, :names, :fail_fast, :no_emoji,
     :prepend_paths, :no_prepend, :exclude_paths, :exclude_names, :base_path,
     :no_dotfile, :warnings, :watch, :yes_i_know, :i_am_being_watched,
@@ -61,7 +61,7 @@ class TLDR
         seed: rand(10_000),
         no_helper: false,
         verbose: false,
-        verbose_cancelled_trace: false,
+        print_interrupted_test_backtraces: false,
         reporter: Reporters::Default,
         parallel: true,
         names: [],
@@ -111,7 +111,7 @@ class TLDR
       end
 
       # Booleans
-      [:no_helper, :verbose, :verbose_cancelled_trace, :fail_fast, :no_emoji, :no_prepend, :warnings, :yes_i_know, :i_am_being_watched].each do |key|
+      [:no_helper, :verbose, :print_interrupted_test_backtraces, :fail_fast, :no_emoji, :no_prepend, :warnings, :yes_i_know, :i_am_being_watched].each do |key|
         merged_args[key] = defaults[key] if merged_args[key].nil?
       end
 

--- a/lib/tldr/value/wip_test.rb
+++ b/lib/tldr/value/wip_test.rb
@@ -1,3 +1,9 @@
 class TLDR
-  WIPTest = Struct.new(:test, :start_time)
+  WIPTest = Struct.new(:test, :start_time, :thread) do
+    attr_reader :backtrace_at_exit
+
+    def capture_backtrace_at_exit
+      @backtrace_at_exit = thread&.backtrace
+    end
+  end
 end

--- a/tests/argv_parser_test.rb
+++ b/tests/argv_parser_test.rb
@@ -6,6 +6,7 @@ class ArgvParserTest < Minitest::Test
       "bar.rb",
       "--seed", "42",
       "-v",
+      "--verbose-cancelled-trace",
       "foo.rb:3",
       "--reporter", "TLDR::Reporters::Base",
       "--no-helper",
@@ -38,6 +39,7 @@ class ArgvParserTest < Minitest::Test
     assert_includes 0..10_000, result.seed
     refute result.no_helper
     refute result.verbose
+    refute result.verbose_cancelled_trace
     assert_equal TLDR::Reporters::Default, result.reporter
     assert_equal ["test/helper.rb"], result.helper_paths
     assert_equal ["lib", "test"], result.load_paths

--- a/tests/argv_parser_test.rb
+++ b/tests/argv_parser_test.rb
@@ -6,7 +6,7 @@ class ArgvParserTest < Minitest::Test
       "bar.rb",
       "--seed", "42",
       "-v",
-      "--verbose-cancelled-trace",
+      "--print-interrupted-test-backtraces",
       "foo.rb:3",
       "--reporter", "TLDR::Reporters::Base",
       "--no-helper",
@@ -39,7 +39,7 @@ class ArgvParserTest < Minitest::Test
     assert_includes 0..10_000, result.seed
     refute result.no_helper
     refute result.verbose
-    refute result.verbose_cancelled_trace
+    refute result.print_interrupted_test_backtraces
     assert_equal TLDR::Reporters::Default, result.reporter
     assert_equal ["test/helper.rb"], result.helper_paths
     assert_equal ["lib", "test"], result.load_paths

--- a/tests/config_test.rb
+++ b/tests/config_test.rb
@@ -46,7 +46,7 @@ class ConfigTest < Minitest::Test
     config = TLDR::Config.new(
       seed: 42,
       verbose: true,
-      verbose_cancelled_trace: true,
+      print_interrupted_test_backtraces: true,
       reporter: TLDR::Reporters::Base,
       helper_paths: ["test_helper.rb"],
       load_paths: ["app", "lib"],
@@ -63,15 +63,15 @@ class ConfigTest < Minitest::Test
     )
 
     assert_equal <<~MSG.chomp, config.to_full_args
-      --seed 42 --verbose --verbose-cancelled-trace --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --parallel --name "/test_*/" --name "test_it" --fail-fast --prepend "a.rb:3" --exclude-path "c.rb:4" --exclude-name "test_b_1" --no-warnings --yes-i-know "a.rb:3" "b.rb"
+      --seed 42 --verbose --print-interrupted-test-backtraces --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --parallel --name "/test_*/" --name "test_it" --fail-fast --prepend "a.rb:3" --exclude-path "c.rb:4" --exclude-name "test_b_1" --no-warnings --yes-i-know "a.rb:3" "b.rb"
     MSG
 
     assert_equal <<~MSG.chomp, config.to_single_path_args("lol.rb")
-      --verbose --verbose-cancelled-trace --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --exclude-name "test_b_1" --no-warnings --yes-i-know "lol.rb"
+      --verbose --print-interrupted-test-backtraces --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --exclude-name "test_b_1" --no-warnings --yes-i-know "lol.rb"
     MSG
 
     assert_equal <<~MSG.chomp, config.to_full_args(ensure_args: ["--i-am-being-watched"])
-      --seed 42 --verbose --verbose-cancelled-trace --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --parallel --name "/test_*/" --name "test_it" --fail-fast --prepend "a.rb:3" --exclude-path "c.rb:4" --exclude-name "test_b_1" --no-warnings --yes-i-know "a.rb:3" "b.rb" --i-am-being-watched
+      --seed 42 --verbose --print-interrupted-test-backtraces --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --parallel --name "/test_*/" --name "test_it" --fail-fast --prepend "a.rb:3" --exclude-path "c.rb:4" --exclude-name "test_b_1" --no-warnings --yes-i-know "a.rb:3" "b.rb" --i-am-being-watched
     MSG
   end
 

--- a/tests/config_test.rb
+++ b/tests/config_test.rb
@@ -46,6 +46,7 @@ class ConfigTest < Minitest::Test
     config = TLDR::Config.new(
       seed: 42,
       verbose: true,
+      verbose_cancelled_trace: true,
       reporter: TLDR::Reporters::Base,
       helper_paths: ["test_helper.rb"],
       load_paths: ["app", "lib"],
@@ -62,15 +63,15 @@ class ConfigTest < Minitest::Test
     )
 
     assert_equal <<~MSG.chomp, config.to_full_args
-      --seed 42 --verbose --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --parallel --name "/test_*/" --name "test_it" --fail-fast --prepend "a.rb:3" --exclude-path "c.rb:4" --exclude-name "test_b_1" --no-warnings --yes-i-know "a.rb:3" "b.rb"
+      --seed 42 --verbose --verbose-cancelled-trace --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --parallel --name "/test_*/" --name "test_it" --fail-fast --prepend "a.rb:3" --exclude-path "c.rb:4" --exclude-name "test_b_1" --no-warnings --yes-i-know "a.rb:3" "b.rb"
     MSG
 
     assert_equal <<~MSG.chomp, config.to_single_path_args("lol.rb")
-      --verbose --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --exclude-name "test_b_1" --no-warnings --yes-i-know "lol.rb"
+      --verbose --verbose-cancelled-trace --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --exclude-name "test_b_1" --no-warnings --yes-i-know "lol.rb"
     MSG
 
     assert_equal <<~MSG.chomp, config.to_full_args(ensure_args: ["--i-am-being-watched"])
-      --seed 42 --verbose --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --parallel --name "/test_*/" --name "test_it" --fail-fast --prepend "a.rb:3" --exclude-path "c.rb:4" --exclude-name "test_b_1" --no-warnings --yes-i-know "a.rb:3" "b.rb" --i-am-being-watched
+      --seed 42 --verbose --verbose-cancelled-trace --reporter TLDR::Reporters::Base --helper "test_helper.rb" --load-path "app" --load-path "lib" --parallel --name "/test_*/" --name "test_it" --fail-fast --prepend "a.rb:3" --exclude-path "c.rb:4" --exclude-name "test_b_1" --no-warnings --yes-i-know "a.rb:3" "b.rb" --i-am-being-watched
     MSG
   end
 

--- a/tests/default_reporter_test.rb
+++ b/tests/default_reporter_test.rb
@@ -24,6 +24,7 @@ class DefaultReporterTest < Minitest::Test
     test_c = TLDR::Test.new(SomeTest, :test_c)
     test_a_result = TLDR::TestResult.new(test_a, nil, 500)
     test_b_wip = TLDR::WIPTest.new(test_b, Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - 1_800_000)
+    test_b_wip.instance_variable_set(:@backtrace_at_exit, ["/path/to/lib/a.rb:in `a'", "/path/to/lib/b.rb:in `b'", "/path/to/lib/c.rb:in `c'"])
 
     subject.before_suite([test_a])
     assert_equal <<~MSG, @io.string
@@ -57,6 +58,41 @@ class DefaultReporterTest < Minitest::Test
 
       🤘 Run the 2 tests that didn't finish:
         bundle exec tldr --seed 42 "tests/default_reporter_test.rb:8:11"
+
+
+      🙈 Suppress this summary with --yes-i-know
+
+      🚨==================== ABORTED RUN ====================🚨
+
+      Finished in XXXms.
+
+      1 test class, 1 test method, 0 failures, 0 errors, 0 skips
+    MSG
+    @io.clear
+
+    config.verbose_cancelled_trace = true
+    subject.after_tldr([test_a, test_b, test_c], [test_b_wip], [test_a_result])
+    assert_equal <<~MSG, scrub_time(@io.string)
+      🥵
+
+      🚨==================== ABORTED RUN ====================🚨
+
+      too long; didn't run!
+
+      🏃 Completed 1 of 3 tests (33%) before running out of time.
+
+      🙅 1 test was cancelled in progress:
+        XXXms - DefaultReporterTest::SomeTest#test_b [tests/default_reporter_test.rb:8]
+          Backtrace at the point of cancellation:
+          /path/to/lib/a.rb:in `a'
+          /path/to/lib/b.rb:in `b'
+          /path/to/lib/c.rb:in `c'
+
+      🐢 Your 1 slowest completed tests:
+        XXXms - DefaultReporterTest::SomeTest#test_a [tests/default_reporter_test.rb:5]
+
+      🤘 Run the 2 tests that didn't finish:
+        bundle exec tldr --seed 42 --verbose-cancelled-trace "tests/default_reporter_test.rb:8:11"
 
 
       🙈 Suppress this summary with --yes-i-know

--- a/tests/default_reporter_test.rb
+++ b/tests/default_reporter_test.rb
@@ -70,7 +70,7 @@ class DefaultReporterTest < Minitest::Test
     MSG
     @io.clear
 
-    config.verbose_cancelled_trace = true
+    config.print_interrupted_test_backtraces = true
     subject.after_tldr([test_a, test_b, test_c], [test_b_wip], [test_a_result])
     assert_equal <<~MSG, scrub_time(@io.string)
       🥵
@@ -92,7 +92,7 @@ class DefaultReporterTest < Minitest::Test
         XXXms - DefaultReporterTest::SomeTest#test_a [tests/default_reporter_test.rb:5]
 
       🤘 Run the 2 tests that didn't finish:
-        bundle exec tldr --seed 42 --verbose-cancelled-trace "tests/default_reporter_test.rb:8:11"
+        bundle exec tldr --seed 42 --print-interrupted-test-backtraces "tests/default_reporter_test.rb:8:11"
 
 
       🙈 Suppress this summary with --yes-i-know

--- a/tests/fixture/suite_summary_too_slow.rb
+++ b/tests/fixture/suite_summary_too_slow.rb
@@ -1,0 +1,11 @@
+class T1 < TLDR
+  def test_1_1
+    assert true
+  end
+end
+
+class T2 < TLDR
+  def test_2_1
+    sleep 2
+  end
+end

--- a/tests/suite_summary_test.rb
+++ b/tests/suite_summary_test.rb
@@ -11,7 +11,7 @@ class SuiteSummaryTest < Minitest::Test
   end
 
   def test_verbose_summary_too_slow
-    result = TLDRunner.should_fail "suite_summary_too_slow.rb", "--verbose-cancelled-trace"
+    result = TLDRunner.should_fail "suite_summary_too_slow.rb", "--verbose-cancelled-trace", ensure_time_bomb: true
 
     assert_match(/Finished in \d+ms./, result.stdout)
     assert_includes result.stdout, <<~MSG.chomp

--- a/tests/suite_summary_test.rb
+++ b/tests/suite_summary_test.rb
@@ -11,7 +11,7 @@ class SuiteSummaryTest < Minitest::Test
   end
 
   def test_verbose_summary_too_slow
-    result = TLDRunner.should_fail "suite_summary_too_slow.rb", "--verbose-cancelled-trace", ensure_time_bomb: true
+    result = TLDRunner.should_fail "suite_summary_too_slow.rb", "--print-interrupted-test-backtraces", ensure_time_bomb: true
 
     assert_match(/Finished in \d+ms./, result.stdout)
     assert_includes result.stdout, <<~MSG.chomp

--- a/tests/suite_summary_test.rb
+++ b/tests/suite_summary_test.rb
@@ -9,4 +9,31 @@ class SuiteSummaryTest < Minitest::Test
       2 test classes, 8 test methods, 2 failures, 2 errors, 2 skips
     MSG
   end
+
+  def test_verbose_summary_too_slow
+    result = TLDRunner.should_fail "suite_summary_too_slow.rb", "--verbose-cancelled-trace"
+
+    assert_match(/Finished in \d+ms./, result.stdout)
+    assert_includes result.stdout, <<~MSG.chomp
+      1 test class, 1 test method, 0 failures, 0 errors, 0 skips
+    MSG
+    assert_includes scrub_time(normalise_abs_paths(result.stderr)), <<~MSG.chomp
+      🙅 1 test was cancelled in progress:
+        XXXms - T2#test_2_1 [tests/fixture/suite_summary_too_slow.rb:8]
+          Backtrace at the point of cancellation:
+          /path/to/tldr/tests/fixture/suite_summary_too_slow.rb:9:in `sleep'
+          /path/to/tldr/tests/fixture/suite_summary_too_slow.rb:9:in `test_2_1'
+    MSG
+  end
+
+  private
+
+  def scrub_time string
+    string.gsub(/(\d+)ms/, "XXXms")
+  end
+
+  def normalise_abs_paths string
+    parent_of_lib_folder = File.expand_path(File.join(__dir__, "../.."))
+    string.gsub(parent_of_lib_folder, "/path/to")
+  end
 end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -48,8 +48,8 @@ end
 module TLDRunner
   Result = Struct.new(:stdout, :stderr, :exit_code, :success?, keyword_init: true)
 
-  def self.should_succeed files, options = nil
-    run(files, options).tap do |result|
+  def self.should_succeed files, options = nil, ensure_time_bomb: false
+    run(files, options, ensure_time_bomb: ensure_time_bomb).tap do |result|
       if !result.success?
         raise <<~MSG
           Ran #{files.inspect} and expected success, but exited code #{result.exit_code}
@@ -64,8 +64,8 @@ module TLDRunner
     end
   end
 
-  def self.should_fail files, options = nil
-    run(files, options).tap do |result|
+  def self.should_fail files, options = nil, ensure_time_bomb: false
+    run(files, options, ensure_time_bomb: ensure_time_bomb).tap do |result|
       if result.success?
         raise <<~MSG
           Ran #{files.inspect} and expected failure, but exited code #{result.exit_code}
@@ -80,11 +80,11 @@ module TLDRunner
     end
   end
 
-  def self.run files, options
+  def self.run files, options, ensure_time_bomb: false
     files = Array(files).map { |file| File.expand_path("fixture/#{file}", __dir__) }
 
     stdout, stderr, status = Open3.capture3 <<~CMD
-      bundle exec tldr #{files.join(" ")} #{options}
+      #{"unset CI;" if ensure_time_bomb} bundle exec tldr #{files.join(" ")} #{options}
     CMD
 
     Result.new(

--- a/tests/wip_test_test.rb
+++ b/tests/wip_test_test.rb
@@ -1,0 +1,42 @@
+require "test_helper"
+
+class WipTestTest < Minitest::Test
+  class SomeTest < TLDR
+    def test_a
+    end
+  end
+
+  def test_backtrace_at_exit
+    test_a = TLDR::Test.new(SomeTest, :test_a)
+    wip_test = TLDR::WIPTest.new(test_a, Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - 1_800_000)
+
+    sleep_line = nil
+    test_thread = Thread.new(name: "test_thread") {
+      wip_test.thread = Thread.current
+      sleep_line = __LINE__ + 1
+      loop { sleep 0.001 }
+    }
+    sleep 0.001 until wip_test.thread
+
+    assert_nil wip_test.backtrace_at_exit
+
+    wip_test.capture_backtrace_at_exit
+    test_thread.exit
+
+    assert_equal [
+      "#{__FILE__}:#{sleep_line}:in `sleep'",
+      "#{__FILE__}:#{sleep_line}:in `block (2 levels) in test_backtrace_at_exit'",
+      "#{__FILE__}:#{sleep_line}:in `loop'",
+      "#{__FILE__}:#{sleep_line}:in `block in test_backtrace_at_exit'"
+    ], wip_test.backtrace_at_exit
+  end
+
+  def test_backtrace_at_exit_without_thread
+    test_a = TLDR::Test.new(SomeTest, :test_a)
+    wip_test = TLDR::WIPTest.new(test_a, Process.clock_gettime(Process::CLOCK_MONOTONIC, :microsecond) - 1_800_000)
+
+    wip_test.capture_backtrace_at_exit
+
+    assert_nil wip_test.backtrace_at_exit
+  end
+end

--- a/tests/wip_test_test.rb
+++ b/tests/wip_test_test.rb
@@ -23,11 +23,19 @@ class WipTestTest < Minitest::Test
     wip_test.capture_backtrace_at_exit
     test_thread.exit
 
+    test_thread_sleep_location = "#{__FILE__}:#{sleep_line}"
+    loop_location = if RUBY_VERSION.delete(".").to_i >= 330
+      # This is different in 3.3.0 and 3.4.0-dev, so handle the difference here.
+      "<internal:kernel>:187"
+    else
+      test_thread_sleep_location
+    end
+
     assert_equal [
-      "#{__FILE__}:#{sleep_line}:in `sleep'",
-      "#{__FILE__}:#{sleep_line}:in `block (2 levels) in test_backtrace_at_exit'",
-      "#{__FILE__}:#{sleep_line}:in `loop'",
-      "#{__FILE__}:#{sleep_line}:in `block in test_backtrace_at_exit'"
+      "#{test_thread_sleep_location}:in `sleep'",
+      "#{test_thread_sleep_location}:in `block (2 levels) in test_backtrace_at_exit'",
+      "#{loop_location}:in `loop'",
+      "#{test_thread_sleep_location}:in `block in test_backtrace_at_exit'"
     ], wip_test.backtrace_at_exit
   end
 


### PR DESCRIPTION
`--verbose-cancelled-trace`

This can help debug whether the cancelled tests were hungup and wouldn't ever have completed due to a parallelisation issue, or if they were just plain too slow.

This has been very helpful for my own debugging in trying to determine the cause of some small tests that usually run super fast, instead taking too long, and hanging indefinitely when env `CI=true` is set and `def $stderr.tty? = false` is mocked to make TLDR skip the 1.8 second time_bomb.

So maybe it's worth becoming an option in this library, to print more helpful information about cancelled tests, when requested =) hence the new verbose option instead of combining it onto `--verbose`, otherwise tests that are always slow (and the dev knows this) would print far too much noise.

What do you think?

Related to #12 