### PR TITLE
Support empty config file

### DIFF
--- a/lib/tldr/yaml_parser.rb
+++ b/lib/tldr/yaml_parser.rb
@@ -4,7 +4,7 @@ class TLDR
   class YamlParser
     def parse path
       require "yaml"
-      YAML.load_file(path)
+      (YAML.load_file(path) || {})
         .transform_keys { |k| k.to_sym }
         .tap do |dotfile_args|
           # Since we don't have shell expansion, we have to glob any paths ourselves

--- a/tests/tldr/yaml_parser_test.rb
+++ b/tests/tldr/yaml_parser_test.rb
@@ -58,4 +58,10 @@ class YamlParserTest < Minitest::Test
       assert_equal "Invalid keys in .sure_jan.yml file: boyfriend", e.message
     end
   end
+
+  def test_empty_file
+    with_temp_file "foo.yml", "" do |yaml_path|
+      assert_equal({}, @subject.parse(yaml_path))
+    end
+  end
 end


### PR DESCRIPTION
Consumers may choose to create an empty config file (e.g. consisting exclusively of breadcrumb comments about how to configure TLDR).

In that case, an empty config hash is a better default than

    undefined method 'transform_keys' for nil (NoMethodError)